### PR TITLE
replaced `TAP` with `tape`, modified package.json to specify testling browser tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # sandwich [![Build Status](https://secure.travis-ci.org/brianloveswords/sandwich.png)](http://travis-ci.org/brianloveswords/sandwich)
+[![browser
+support](https://ci.testling.com/AWinterman/sandwich.png)](https://ci.testling.com/AWinterman/sandwich)
 
 Iterator generator for getting ordered combinations of items.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "devDependencies": {
-    "tape": "~1.0.4",
+    "tape": "~1.0.4"
   },
   "scripts": {
     "test": "node test/*.test.js"

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "test": "test"
   },
   "devDependencies": {
-    "tap": "~0.3.1",
-    "deep-equal": "0.0.0"
+    "tape": "~1.0.4",
   },
   "scripts": {
-    "test": "./node_modules/.bin/tap test/*.test.js"
+    "test": "node test/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -24,5 +23,24 @@
     "streaming"
   ],
   "author": "Brian J. Brennan",
-  "license": "MIT"
+  "license": "MIT",
+  "testling": {
+    "files":"test/*.test.js",
+    "browsers": [
+      "ie8",
+      "ie9",
+      "ie10",
+      "ff19",
+      "firefox/nightly",
+      "opera/10", 
+      "opera/next",
+      "chrome/canary",
+      "chrome/25",
+      "safari/5.1",
+      "safari/6.0",
+      "iphone",
+      "ipad",
+      "android-browser"
+    ]
+  }
 }

--- a/test/places.test.js
+++ b/test/places.test.js
@@ -1,4 +1,4 @@
-var test = require('tap').test;
+var test = require('tape');
 var Places = require('../places');
 
 test('generic places testing', function (t) {

--- a/test/sandwich.test.js
+++ b/test/sandwich.test.js
@@ -1,5 +1,5 @@
 var sandwich = require('..');
-var test = require('tap').test;
+var test = require('tape');
 var pathutil = require('path');
 var fs = require('fs');
 var deepEqual = require('deep-equal');


### PR DESCRIPTION
This way people can see which browsers can run this module, perhaps not the intended use case, but definitely useful. You'd need to follow the directions [here](https://ci.testling.com/#hook) to actually have testling-ci run the tests on push.

Let me know if you need anything else to make the merge happen. You can see how the badge looks on the master branch of my fork.
